### PR TITLE
ux(invest): skeleton list for invoice rows before real data (#14)

### DIFF
--- a/app/invest/page.js
+++ b/app/invest/page.js
@@ -1,19 +1,106 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import InvoiceListSkeleton from "@/components/InvoiceListSkeleton";
+
+/**
+ * Mock invoice data — replace with real API call once the backend endpoint
+ * is available (follow-up: link backend issue here).
+ *
+ * Contract per item: { id, issuer, amount, currency, dueDate, yield, status }
+ */
+const MOCK_INVOICES = [
+  {
+    id: "inv-001",
+    issuer: "Acme Supplies Ltd",
+    amount: "12,500",
+    currency: "USD",
+    dueDate: "2026-06-15",
+    yield: "8.2%",
+    status: "Open",
+  },
+  {
+    id: "inv-002",
+    issuer: "Bright Logistics GmbH",
+    amount: "7,800",
+    currency: "EUR",
+    dueDate: "2026-07-01",
+    yield: "7.5%",
+    status: "Open",
+  },
+  {
+    id: "inv-003",
+    issuer: "Sunrise Exports Pte",
+    amount: "22,000",
+    currency: "USD",
+    dueDate: "2026-05-30",
+    yield: "9.1%",
+    status: "Open",
+  },
+];
+
+// DEV-only delay (ms) to make the skeleton visible during local development.
+const DEV_DELAY = process.env.NODE_ENV === "development" ? 1500 : 0;
+
 export default function InvestPage() {
+  const [invoices, setInvoices] = useState(null); // null = loading
+
+  useEffect(() => {
+    const timer = setTimeout(() => setInvoices(MOCK_INVOICES), DEV_DELAY);
+    return () => clearTimeout(timer);
+  }, []);
+
   return (
     <div className="min-h-screen bg-slate-950 text-slate-100">
       <header className="border-b border-slate-800 px-6 py-4">
-        <a href="/" className="text-xl font-semibold tracking-tight text-cyan-400 hover:underline">
+        <Link
+          href="/"
+          className="text-xl font-semibold tracking-tight text-cyan-400 hover:underline"
+        >
           ← LiquiFact
-        </a>
+        </Link>
       </header>
+
       <main className="max-w-4xl mx-auto px-6 py-12">
-        <h1 className="text-2xl font-bold mb-6">Invest</h1>
+        <h1 className="text-2xl font-bold mb-2">Invest</h1>
         <p className="text-slate-400 mb-8">
-          Browse tokenized invoices and fund them. Principal + yield at maturity.
+          Browse tokenized invoices and fund them. Principal&nbsp;+&nbsp;yield
+          at maturity.
         </p>
-        <div className="rounded-xl border border-slate-800 bg-slate-900/30 p-8 text-center text-slate-500">
-          No investable invoices. Connect wallet to see the marketplace.
-        </div>
+
+        {invoices === null ? (
+          <InvoiceListSkeleton rows={3} />
+        ) : invoices.length === 0 ? (
+          <div className="rounded-xl border border-slate-800 bg-slate-900/30 p-8 text-center text-slate-500">
+            No investable invoices. Connect wallet to see the marketplace.
+          </div>
+        ) : (
+          <ul className="space-y-4">
+            {invoices.map((inv) => (
+              <li
+                key={inv.id}
+                className="rounded-xl border border-slate-800 bg-slate-900/50 p-5"
+              >
+                <div className="flex items-center justify-between mb-3">
+                  <span className="font-medium text-slate-100">
+                    {inv.issuer}
+                  </span>
+                  <span className="text-xs font-semibold px-2 py-1 rounded-full bg-cyan-900/60 text-cyan-300">
+                    {inv.status}
+                  </span>
+                </div>
+                <div className="flex gap-6 text-sm text-slate-400">
+                  <span>
+                    {inv.currency}&nbsp;{inv.amount}
+                  </span>
+                  <span>Yield&nbsp;{inv.yield}</span>
+                  <span>Due&nbsp;{inv.dueDate}</span>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
       </main>
     </div>
   );

--- a/app/invoices/page.js
+++ b/app/invoices/page.js
@@ -1,10 +1,12 @@
+import Link from "next/link";
+
 export default function InvoicesPage() {
   return (
     <div className="min-h-screen bg-slate-950 text-slate-100">
       <header className="border-b border-slate-800 px-6 py-4">
-        <a href="/" className="text-xl font-semibold tracking-tight text-cyan-400 hover:underline">
+        <Link href="/" className="text-xl font-semibold tracking-tight text-cyan-400 hover:underline">
           ← LiquiFact
-        </a>
+        </Link>
       </header>
       <main className="max-w-4xl mx-auto px-6 py-12">
         <h1 className="text-2xl font-bold mb-6">Invoices</h1>

--- a/components/InvoiceListSkeleton.jsx
+++ b/components/InvoiceListSkeleton.jsx
@@ -1,0 +1,33 @@
+/**
+ * InvoiceListSkeleton
+ *
+ * Renders N placeholder rows that mirror the real invoice-list card layout.
+ * Swap this out once the API contract is finalised (see issue #14 follow-up).
+ *
+ * Mock data contract (per row):
+ *   { id, issuer, amount, currency, dueDate, yield, status }
+ */
+export default function InvoiceListSkeleton({ rows = 3 }) {
+  return (
+    <ul aria-label="Loading invoices" aria-busy="true" className="space-y-4">
+      {Array.from({ length: rows }).map((_, i) => (
+        <li
+          key={i}
+          className="rounded-xl border border-slate-800 bg-slate-900/50 p-5 animate-pulse"
+        >
+          {/* Row: issuer + status badge */}
+          <div className="flex items-center justify-between mb-3">
+            <div className="h-4 w-36 rounded bg-slate-700" />
+            <div className="h-5 w-20 rounded-full bg-slate-700" />
+          </div>
+          {/* Row: amount + yield + due date */}
+          <div className="flex gap-6">
+            <div className="h-3 w-24 rounded bg-slate-800" />
+            <div className="h-3 w-16 rounded bg-slate-800" />
+            <div className="h-3 w-28 rounded bg-slate-800" />
+          </div>
+        </li>
+      ))}
+    </ul>
+  );
+}


### PR DESCRIPTION
Closes #14

---

## Summary

Implements issue #14 — skeleton loading for the invest page to reduce layout jump while invoice data loads.

## Changes

- **`components/InvoiceListSkeleton.jsx`** — new component: 3 animated-pulse rows matching the real card layout (issuer name, status badge, amount / yield / due-date fields). Uses Tailwind `animate-pulse` with slate palette.
- **`app/invest/page.js`** — converted to a client component; shows `<InvoiceListSkeleton rows={3} />` while `invoices === null`, then renders mock data. A `DEV_DELAY` of 1 500 ms (dev only, zero in production) makes the skeleton visible during local development.
- **`app/invoices/page.js`** — fixed pre-existing `@next/next/no-html-link-for-pages` lint error (`<a>` → `<Link>`).

## Mock data contract

Each invoice row exposes: `{ id, issuer, amount, currency, dueDate, yield, status }`. Wire to the real API endpoint in a follow-up backend issue.

## CI

- `npm run lint` ✅
- `npm run build` ✅ (all 4 routes compile, /invest renders as static)

## Accessibility notes

- Skeleton `<ul>` carries `aria-label="Loading invoices"` and `aria-busy="true"` so screen readers announce the loading state.
- Colour contrast: skeleton blocks use `bg-slate-700` / `bg-slate-800` on `bg-slate-900/50` — decorative placeholders, no text contrast requirement.
- Keyboard: no interactive elements added; existing nav link uses `<Link>` (focusable).

## Responsive

Layout is single-column fluid (`max-w-4xl mx-auto`); skeleton rows scale naturally on mobile.