### PR TITLE
Refactor(ux): centralize static copy and add footer/example markers #22 #16 #24

### DIFF
--- a/app/copy/en.js
+++ b/app/copy/en.js
@@ -1,0 +1,31 @@
+export const copy = {
+  home: {
+    heroTitle: "Global Invoice Liquidity Network on Stellar",
+    heroSub: "Unlock liquidity from unpaid invoices instantly. SMEs get working capital; investors earn yield. Tokenized invoices, escrow on Soroban.",
+    boxBusinessTitle: "For Businesses",
+    boxBusinessSub: "Upload invoices, get instant stablecoin liquidity.",
+    boxInvestTitle: "For Investors",
+    boxInvestSub: "Fund tokenized invoices and earn yield at maturity."
+  },
+  invest: {
+    title: "Invest",
+    subtext: "Browse tokenized invoices and fund them. Principal + yield at maturity.",
+    emptyState: "No investable invoices. Connect wallet to see the marketplace.",
+    exampleHeading: "Example Marketplace Invoice",
+    exampleDisclaimer: "EXAMPLE ONLY. NOT A LIVE OFFERING."
+  },
+  invoices: {
+    title: "Invoices",
+    subtext: "Upload and tokenize invoices. List will be wired to the API and Stellar.",
+    emptyState: "No invoices yet. Connect wallet and upload your first invoice."
+  },
+  layout: {
+    backToHome: "← LiquiFact",
+    connectWallet: "Connect Wallet"
+  },
+  footer: {
+    docs: "Documentation",
+    status: "System Status",
+    contact: "Contact Support"
+  }
+};

--- a/app/invest/page.js
+++ b/app/invest/page.js
@@ -1,18 +1,34 @@
+import { copy } from '../copy/en';
+
 export default function InvestPage() {
   return (
     <div className="min-h-screen bg-slate-950 text-slate-100">
       <header className="border-b border-slate-800 px-6 py-4">
         <a href="/" className="text-xl font-semibold tracking-tight text-cyan-400 hover:underline">
-          ← LiquiFact
+          {copy.layout.backToHome}
         </a>
       </header>
       <main className="max-w-4xl mx-auto px-6 py-12">
-        <h1 className="text-2xl font-bold mb-6">Invest</h1>
+        <h1 className="text-2xl font-bold mb-6">{copy.invest.title}</h1>
         <p className="text-slate-400 mb-8">
-          Browse tokenized invoices and fund them. Principal + yield at maturity.
+          {copy.invest.subtext}
         </p>
+
+        {/* Issue #24 Example marketplace row */}
+        <div className="mb-8 rounded-xl border border-slate-700/50 bg-slate-900/50 p-6 flex items-center justify-between opacity-70 relative overflow-hidden">
+          <div className="absolute -inset-1 bg-[repeating-linear-gradient(45deg,transparent,transparent_10px,rgba(255,255,255,0.03)_10px,rgba(255,255,255,0.03)_20px)] pointer-events-none"></div>
+          <div>
+            <h2 className="font-semibold text-lg text-slate-300">{copy.invest.exampleHeading}</h2>
+            <p className="text-sm text-slate-500 mt-1">Invoice #EX-1029 • Expected yield: 8% APR</p>
+          </div>
+          <div className="text-right">
+            <p className="font-bold text-slate-300">10,000 USDC</p>
+            <p className="text-xs text-orange-400/80 font-medium uppercase tracking-wider mt-1">{copy.invest.exampleDisclaimer}</p>
+          </div>
+        </div>
+
         <div className="rounded-xl border border-slate-800 bg-slate-900/30 p-8 text-center text-slate-500">
-          No investable invoices. Connect wallet to see the marketplace.
+          {copy.invest.emptyState}
         </div>
       </main>
     </div>

--- a/app/invoices/page.js
+++ b/app/invoices/page.js
@@ -1,18 +1,20 @@
+import { copy } from '../copy/en';
+
 export default function InvoicesPage() {
   return (
     <div className="min-h-screen bg-slate-950 text-slate-100">
       <header className="border-b border-slate-800 px-6 py-4">
         <a href="/" className="text-xl font-semibold tracking-tight text-cyan-400 hover:underline">
-          ← LiquiFact
+          {copy.layout.backToHome}
         </a>
       </header>
       <main className="max-w-4xl mx-auto px-6 py-12">
-        <h1 className="text-2xl font-bold mb-6">Invoices</h1>
+        <h1 className="text-2xl font-bold mb-6">{copy.invoices.title}</h1>
         <p className="text-slate-400 mb-8">
-          Upload and tokenize invoices. List will be wired to the API and Stellar.
+          {copy.invoices.subtext}
         </p>
         <div className="rounded-xl border border-slate-800 bg-slate-900/30 p-8 text-center text-slate-500">
-          No invoices yet. Connect wallet and upload your first invoice.
+          {copy.invoices.emptyState}
         </div>
       </main>
     </div>

--- a/app/layout.js
+++ b/app/layout.js
@@ -1,5 +1,6 @@
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import Footer from "../components/Footer";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -23,6 +24,7 @@ export default function RootLayout({ children }) {
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
         {children}
+        <Footer />
       </body>
     </html>
   );

--- a/app/page.js
+++ b/app/page.js
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState } from 'react';
+import { copy } from './copy/en';
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001';
 
@@ -29,16 +30,16 @@ export default function Home() {
           type="button"
           className="rounded-full bg-cyan-500/20 text-cyan-400 px-4 py-2 text-sm font-medium hover:bg-cyan-500/30 transition-colors"
         >
-          Connect Wallet
+          {copy.layout.connectWallet}
         </button>
       </header>
 
       <main className="max-w-4xl mx-auto px-6 py-16">
         <h1 className="text-4xl font-bold tracking-tight mb-4">
-          Global Invoice Liquidity Network on Stellar
+          {copy.home.heroTitle}
         </h1>
         <p className="text-slate-400 text-lg mb-12 max-w-2xl">
-          Unlock liquidity from unpaid invoices instantly. SMEs get working capital; investors earn yield. Tokenized invoices, escrow on Soroban.
+          {copy.home.heroSub}
         </p>
 
         <div className="grid gap-6 sm:grid-cols-2 mb-12">
@@ -46,15 +47,15 @@ export default function Home() {
             href="/invoices"
             className="block rounded-xl border border-slate-700 bg-slate-900/50 p-6 hover:border-cyan-500/50 transition-colors"
           >
-            <h2 className="text-lg font-semibold text-cyan-400 mb-2">For Businesses</h2>
-            <p className="text-slate-400 text-sm">Upload invoices, get instant stablecoin liquidity.</p>
+            <h2 className="text-lg font-semibold text-cyan-400 mb-2">{copy.home.boxBusinessTitle}</h2>
+            <p className="text-slate-400 text-sm">{copy.home.boxBusinessSub}</p>
           </a>
           <a
             href="/invest"
             className="block rounded-xl border border-slate-700 bg-slate-900/50 p-6 hover:border-cyan-500/50 transition-colors"
           >
-            <h2 className="text-lg font-semibold text-cyan-400 mb-2">For Investors</h2>
-            <p className="text-slate-400 text-sm">Fund tokenized invoices and earn yield at maturity.</p>
+            <h2 className="text-lg font-semibold text-cyan-400 mb-2">{copy.home.boxInvestTitle}</h2>
+            <p className="text-slate-400 text-sm">{copy.home.boxInvestSub}</p>
           </a>
         </div>
 

--- a/components/Footer.jsx
+++ b/components/Footer.jsx
@@ -1,0 +1,20 @@
+import { copy } from '../app/copy/en';
+
+export default function Footer() {
+  return (
+    <footer className="border-t border-slate-800 bg-slate-950 px-6 py-8">
+      <div className="max-w-4xl mx-auto flex flex-wrap items-center gap-6 text-sm text-slate-500">
+        {/* TODO: Add actual links when ready */}
+        <a href="#" className="hover:text-cyan-400 transition-colors">
+          {copy.footer.docs}
+        </a>
+        <a href="#" className="hover:text-cyan-400 transition-colors">
+          {copy.footer.status}
+        </a>
+        <a href="#" className="hover:text-cyan-400 transition-colors">
+          {copy.footer.contact}
+        </a>
+      </div>
+    </footer>
+  );
+}


### PR DESCRIPTION
Hardcoded strings, missing trust links, and lack of example data blur user expectations and complicate future i18n.

Solution: Centralized copy in a dictionary object, introduced a global footer component with trust links, and added a demarcated example row for education.

Impact: Streamlines maintenance for copy changes, improves perceived legitimacy, and provides clear user education for marketplace behavior.

Issue #22 (Copy Object):

Created app/copy/en.js containing a unified dictionary 
Swapped hardcoded text into {copy.X.Y} variables on page.js, invest/page.js, and invoices/page.js. This creates no visible difference but cleanly prepares for i18n.
Issue #16 (Footer with Trust Links):

Created components/Footer.jsx containing the requested placeholder links (#) for Docs, System Status, and Contact Support with proper TODOs.
Inserted <Footer /> into app/layout.js so it renders globally at the bottom of the structure and perfectly inherits the dark Slate interface theme.
Issue #24 (Example Marketplace Row):

Inserted a single responsive layout block (div) directly into app/invest/page.js .
Added opacity-70 and a CSS repeating linear-gradient to serve as an unmistakable watermark. Applied explicit uppercase warnings ("EXAMPLE ONLY").

Closes #22, closes #16, closes #24