### PR TITLE
a11y(ux): ensure ≥44px touch targets on key controls and header

### DIFF
--- a/app/invest/page.js
+++ b/app/invest/page.js
@@ -57,7 +57,7 @@ export default function InvestPage() {
       <header className="border-b border-slate-800 px-6 py-4">
         <Link
           href="/"
-          className="text-xl font-semibold tracking-tight text-cyan-400 hover:underline"
+          className="inline-block py-3 text-xl font-semibold tracking-tight text-cyan-400 hover:underline"
         >
           ← LiquiFact
         </Link>
@@ -76,33 +76,35 @@ export default function InvestPage() {
             No investable invoices. Connect wallet to see the marketplace.
           </div>
         ) : (
-          <ul className="space-y-4">
-            {invoices.map((inv) => (
-              <li
-                key={inv.id}
-                className="rounded-xl border border-slate-800 bg-slate-900/50 p-5"
-              >
-                <div className="flex items-center justify-between mb-3">
-                  <span className="font-medium text-slate-100">
-                    {inv.issuer}
-                  </span>
-                  <span className="text-xs font-semibold px-2 py-1 rounded-full bg-cyan-900/60 text-cyan-300">
-                    {inv.status}
-                  </span>
-                </div>
-                <div className="flex gap-6 text-sm text-slate-400">
-                  <span>
-                    {inv.currency}&nbsp;{inv.amount}
-                  </span>
-                  <span>Est. yield&nbsp;{inv.yield}</span>
-                  <span>Maturity&nbsp;{inv.dueDate}</span>
-                </div>
-              </li>
-            ))}
-          </ul>
-          <div className="mt-6 rounded-xl border border-slate-800 bg-slate-900/30 p-4 text-sm text-slate-400">
-            Note: Yield references are educational only and reflect on-chain basis-point assumptions. Invoice contracts settle at maturity.
-          </div>
+          <>
+            <ul className="space-y-4">
+              {invoices.map((inv) => (
+                <li
+                  key={inv.id}
+                  className="rounded-xl border border-slate-800 bg-slate-900/50 p-5"
+                >
+                  <div className="flex items-center justify-between mb-3">
+                    <span className="font-medium text-slate-100">
+                      {inv.issuer}
+                    </span>
+                    <span className="text-xs font-semibold px-2 py-1 rounded-full bg-cyan-900/60 text-cyan-300">
+                      {inv.status}
+                    </span>
+                  </div>
+                  <div className="flex gap-6 text-sm text-slate-400">
+                    <span>
+                      {inv.currency}&nbsp;{inv.amount}
+                    </span>
+                    <span>Est. yield&nbsp;{inv.yield}</span>
+                    <span>Maturity&nbsp;{inv.dueDate}</span>
+                  </div>
+                </li>
+              ))}
+            </ul>
+            <div className="mt-6 rounded-xl border border-slate-800 bg-slate-900/30 p-4 text-sm text-slate-400">
+              Note: Yield references are educational only and reflect on-chain basis-point assumptions. Invoice contracts settle at maturity.
+            </div>
+          </>
         )}
       </main>
     </div>

--- a/app/invoices/page.js
+++ b/app/invoices/page.js
@@ -236,13 +236,13 @@ export default function InvoicesPage() {
       <header className="border-b border-slate-800 px-6 py-4 flex items-center justify-between">
         <Link
           href="/"
-          className="text-xl font-semibold tracking-tight text-cyan-400 hover:underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-cyan-400 rounded"
+          className="inline-block py-3 text-xl font-semibold tracking-tight text-cyan-400 hover:underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-cyan-400 rounded"
         >
           ← LiquiFact
         </Link>
         <button
           type="button"
-          className="rounded-full bg-cyan-500/20 text-cyan-400 px-4 py-2 text-sm font-medium hover:bg-cyan-500/30 transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-cyan-400"
+          className="rounded-full bg-cyan-500/20 text-cyan-400 px-4 py-3 text-sm font-medium hover:bg-cyan-500/30 transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-cyan-400"
         >
           Connect Wallet
         </button>

--- a/app/page.js
+++ b/app/page.js
@@ -28,7 +28,7 @@ export default function Home() {
         <span className="text-xl font-semibold tracking-tight">LiquiFact</span>
         <button
           type="button"
-          className="rounded-full bg-cyan-500/20 text-cyan-400 px-4 py-2 text-sm font-medium hover:bg-cyan-500/30 transition-colors"
+          className="rounded-full bg-cyan-500/20 text-cyan-400 px-4 py-3 text-sm font-medium hover:bg-cyan-500/30 transition-colors"
         >
           {copy.layout.connectWallet}
         </button>
@@ -65,7 +65,7 @@ export default function Home() {
             type="button"
             onClick={checkApi}
             disabled={loading}
-            className="rounded-lg bg-slate-800 px-4 py-2 text-sm font-medium hover:bg-slate-700 disabled:opacity-50"
+            className="rounded-lg bg-slate-800 px-4 py-3 text-sm font-medium hover:bg-slate-700 disabled:opacity-50"
           >
             {loading ? 'Checking…' : 'Check backend health'}
           </button>

--- a/components/ErrorBanner.jsx
+++ b/components/ErrorBanner.jsx
@@ -39,7 +39,7 @@ export default function ErrorBanner({
           <button
             type="button"
             onClick={onAction}
-            className="inline-flex items-center justify-center rounded-xl bg-red-500 px-4 py-2 text-sm font-semibold text-white transition hover:bg-red-400 focus:outline-none focus:ring-2 focus:ring-cyan-300 focus:ring-offset-2 focus:ring-offset-slate-950"
+            className="inline-flex items-center justify-center rounded-xl bg-red-500 px-4 py-3 text-sm font-semibold text-white transition hover:bg-red-400 focus:outline-none focus:ring-2 focus:ring-cyan-300 focus:ring-offset-2 focus:ring-offset-slate-950"
           >
             {actionLabel}
           </button>

--- a/components/Footer.jsx
+++ b/components/Footer.jsx
@@ -5,13 +5,13 @@ export default function Footer() {
     <footer className="border-t border-slate-800 bg-slate-950 px-6 py-8">
       <div className="max-w-4xl mx-auto flex flex-wrap items-center gap-6 text-sm text-slate-500">
         {/* TODO: Add actual links when ready */}
-        <a href="#" className="hover:text-cyan-400 transition-colors">
+        <a href="#" className="inline-block py-3 hover:text-cyan-400 transition-colors">
           {copy.footer.docs}
         </a>
-        <a href="#" className="hover:text-cyan-400 transition-colors">
+        <a href="#" className="inline-block py-3 hover:text-cyan-400 transition-colors">
           {copy.footer.status}
         </a>
-        <a href="#" className="hover:text-cyan-400 transition-colors">
+        <a href="#" className="inline-block py-3 hover:text-cyan-400 transition-colors">
           {copy.footer.contact}
         </a>
       </div>

--- a/components/WalletStatus.jsx
+++ b/components/WalletStatus.jsx
@@ -121,7 +121,7 @@ export default function WalletStatus() {
   const config = getStateConfig(walletState);
 
   const getButtonStyles = (variant) => {
-    const baseStyles = 'rounded-full px-4 py-2 text-sm font-medium transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-slate-950';
+    const baseStyles = 'rounded-full px-4 py-3 text-sm font-medium transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-slate-950';
     
     switch (variant) {
       case 'primary':


### PR DESCRIPTION
Closes #25 

### Overview
This PR addresses **Issue #25**, focusing on accessibility and mobile ergonomics by ensuring all primary and secondary interactive elements have a minimum touch target size of **44x44 CSS pixels**, as per WCAG 2.1 Success Criterion 2.5.5.

### Changes
- **Header**: Updated "Connect Wallet" buttons and "Back to Home" links to use `py-3` padding.
- **Home Page**: Audited landing cards and updated the "Check backend health" button.
- **Components**: 
  - Updated `WalletStatus.jsx` base button styles for consistent sizing.
  - Increased padding for the `ErrorBanner` action button.
  - Added `inline-block` and `py-3` to footer links for improved tap accuracy.
- **Clean Code**: Resolved a pre-existing JSX fragment error in `app/invest/page.js` that occurred during the refactor.

### Verification
- **Touch Target Audit**: All modified elements were verified in Chrome DevTools to have a computed height of at least 44px.
- **Responsive Check**: Verified that the increased padding does not cause layout shifts or overlap on small screens (320px+).
- **Accessibility**: Keyboard navigation and focus rings (`focus-visible`) remain intact and functional.