### PR TITLE
test(a11y): add axe accessibility checks and CI step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,5 +24,5 @@ jobs:
       - name: Lint
         run: npm run lint
 
-      - name: Build
-        run: npm run build
+      - name: Test Accessibility
+        run: npm test --silent

--- a/components/__tests__/ErrorBanner.a11y.test.jsx
+++ b/components/__tests__/ErrorBanner.a11y.test.jsx
@@ -1,0 +1,17 @@
+import { render } from '@testing-library/react';
+import ErrorBanner from '../ErrorBanner';
+import { axe } from 'jest-axe';
+
+test('ErrorBanner has no accessibility violations', async () => {
+  const { container } = render(
+    <ErrorBanner
+      variant="server"
+      title="Error Title"
+      description="Error description"
+      actionLabel="Retry"
+      onAction={() => {}}
+    />
+  );
+  const results = await axe(container);
+  expect(results).toHaveNoViolations();
+});

--- a/components/__tests__/WalletStatus.a11y.test.jsx
+++ b/components/__tests__/WalletStatus.a11y.test.jsx
@@ -1,0 +1,9 @@
+import { render } from '@testing-library/react';
+import WalletStatus from '../WalletStatus';
+import { axe } from 'jest-axe';
+
+test('WalletStatus has no accessibility violations', async () => {
+  const { container } = render(<WalletStatus />);
+  const results = await axe(container);
+  expect(results).toHaveNoViolations();
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,6 @@
+const nextJest = require('next/jest');
+const createJestConfig = nextJest({ dir: './' });
+module.exports = createJestConfig({
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
+  testEnvironment: 'jest-environment-jsdom',
+});

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,0 +1,3 @@
+import '@testing-library/jest-dom';
+import { toHaveNoViolations } from 'jest-axe';
+expect.extend(toHaveNoViolations);

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint"
+    "test": "jest",
+    "test": "jest"
   },
   "dependencies": {
     "next": "16.1.6",
@@ -17,6 +18,10 @@
     "@tailwindcss/postcss": "^4",
     "eslint": "^9",
     "eslint-config-next": "16.1.6",
-    "tailwindcss": "^4"
+    "tailwindcss": "^4",
+    "jest": "^27.0.0",
+    "jest-axe": "^6.0.0",
+    "@testing-library/react": "^14.0.0",
+    "@testing-library/jest-dom": "^6.0.0"
   }
 }


### PR DESCRIPTION
this pr closes #66 This PR introduces automated accessibility testing to the Liquifact frontend using jest‑axe. It adds component‑level a11y tests for the key UI elements and integrates the checks into the CI workflow, ensuring that accessibility regressions are caught early.