### PR TITLE
feat(a11y): announce invest list load completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,11 @@ Skeleton placeholder for invoice list while loading.
 **Props:**
 - `rows` (number, default `5`): Number of placeholder rows.
 
+### Invest Marketplace
+The `/invest` page uses a polite live region to announce when the skeleton resolves:
+- loaded: `N investable invoices loaded`
+- empty: `No invoices available`
+
 ### WalletStatus
 Shows connection status of Stellar wallet.
 **Props:**

--- a/app/invest/page.js
+++ b/app/invest/page.js
@@ -2,7 +2,9 @@
 
 import { useEffect, useState } from "react";
 import Link from "next/link";
+import ErrorBanner from "@/components/ErrorBanner";
 import InvoiceListSkeleton from "@/components/InvoiceListSkeleton";
+import { copy } from "../copy/en";
 
 /**
  * Mock invoice data — replace with real API call once the backend endpoint
@@ -44,13 +46,59 @@ const MOCK_INVOICES = [
 // DEV-only delay (ms) to make the skeleton visible during local development.
 const DEV_DELAY = process.env.NODE_ENV === "development" ? 1500 : 0;
 
-export default function InvestPage() {
+function loadMockInvoices() {
+  return new Promise((resolve) => {
+    setTimeout(() => resolve(MOCK_INVOICES), DEV_DELAY);
+  });
+}
+
+export function getInvoiceLoadAnnouncement(invoices) {
+  if (!Array.isArray(invoices) || invoices.length === 0) {
+    return "No invoices available";
+  }
+
+  return `${invoices.length} investable invoices loaded`;
+}
+
+export function InvestMarketplace({ loadInvoices = loadMockInvoices }) {
   const [invoices, setInvoices] = useState(null); // null = loading
+  const [statusMessage, setStatusMessage] = useState("");
+  const [loadError, setLoadError] = useState("");
 
   useEffect(() => {
-    const timer = setTimeout(() => setInvoices(MOCK_INVOICES), DEV_DELAY);
-    return () => clearTimeout(timer);
-  }, []);
+    let isActive = true;
+
+    const announceLoadCompletion = async () => {
+      try {
+        const nextInvoices = await loadInvoices();
+
+        if (!isActive) {
+          return;
+        }
+
+        const normalizedInvoices = Array.isArray(nextInvoices)
+          ? nextInvoices
+          : [];
+
+        setInvoices(normalizedInvoices);
+        setStatusMessage(getInvoiceLoadAnnouncement(normalizedInvoices));
+      } catch {
+        if (!isActive) {
+          return;
+        }
+
+        setInvoices([]);
+        setLoadError("Unable to load investable invoices right now.");
+        setStatusMessage("Unable to load investable invoices.");
+      }
+    };
+
+    void announceLoadCompletion();
+
+    return () => {
+      isActive = false;
+    };
+  }, [loadInvoices]);
 
   return (
     <div className="min-h-screen bg-slate-950 text-slate-100">
@@ -64,9 +112,13 @@ export default function InvestPage() {
       </header>
 
       <main className="max-w-4xl mx-auto px-6 py-12">
-        <h1 className="text-2xl font-bold mb-2">Invest</h1>
+        <h1 className="text-2xl font-bold mb-2">{copy.invest.title}</h1>
         <p className="text-slate-400 mb-8">
-          Browse tokenized invoices and fund them. Estimated yield is shown for educational purposes; actual payment is received at invoice maturity.
+          {copy.invest.subtext}
+        </p>
+
+        <p role="status" aria-live="polite" aria-atomic="true" className="sr-only">
+          {statusMessage}
         </p>
 
         {/* Filter Controls - Disabled with Coming Soon Indicators */}
@@ -161,11 +213,18 @@ export default function InvestPage() {
           </div>
         </div>
 
-        {invoices === null ? (
+        {loadError ? (
+          <ErrorBanner
+            variant="error"
+            title="Unable to load investable invoices"
+            description={loadError}
+            previewLabel="Marketplace status"
+          />
+        ) : invoices === null ? (
           <InvoiceListSkeleton rows={3} />
         ) : invoices.length === 0 ? (
           <div className="rounded-xl border border-slate-800 bg-slate-900/30 p-8 text-center text-slate-300">
-            No investable invoices. Connect wallet to see the marketplace.
+            {copy.invest.emptyState}
           </div>
         ) : (
           <>
@@ -201,4 +260,8 @@ export default function InvestPage() {
       </main>
     </div>
   );
+}
+
+export default function InvestPage() {
+  return <InvestMarketplace />;
 }

--- a/app/invest/page.test.jsx
+++ b/app/invest/page.test.jsx
@@ -1,0 +1,166 @@
+import "@testing-library/jest-dom";
+import { act, render, screen } from "@testing-library/react";
+import {
+  getInvoiceLoadAnnouncement,
+  InvestMarketplace,
+} from "./page";
+
+jest.mock("next/link", () => {
+  function MockLink({ href, children, ...props }) {
+    return (
+      <a href={href} {...props}>
+        {children}
+      </a>
+    );
+  }
+
+  return {
+    __esModule: true,
+    default: MockLink,
+  };
+});
+
+function createDeferredLoader(invoices, delayMs = 0) {
+  return jest.fn(
+    () =>
+      new Promise((resolve) => {
+        setTimeout(() => resolve(invoices), delayMs);
+      }),
+  );
+}
+
+function createPendingLoader() {
+  return jest.fn(() => new Promise(() => {}));
+}
+
+async function flushTimers(delayMs = 0) {
+  await act(async () => {
+    jest.advanceTimersByTime(delayMs);
+    await Promise.resolve();
+  });
+}
+
+describe("InvestMarketplace", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  it("keeps the skeleton busy state while invoices are still loading", () => {
+    render(<InvestMarketplace loadInvoices={createPendingLoader()} />);
+
+    const skeleton = screen.getByRole("list", {
+      name: /loading investable invoices/i,
+    });
+
+    expect(skeleton).toHaveAttribute("aria-busy", "true");
+    expect(screen.getByRole("status")).toHaveTextContent("");
+  });
+
+  it("announces the loaded invoice count exactly once after the list resolves", async () => {
+    const invoices = [
+      {
+        id: "inv-001",
+        issuer: "Acme Supplies Ltd",
+        amount: "12,500",
+        currency: "USD",
+        dueDate: "2026-06-15",
+        yield: "8.2%",
+        status: "Open",
+      },
+      {
+        id: "inv-002",
+        issuer: "Bright Logistics GmbH",
+        amount: "7,800",
+        currency: "EUR",
+        dueDate: "2026-07-01",
+        yield: "7.5%",
+        status: "Open",
+      },
+      {
+        id: "inv-003",
+        issuer: "Sunrise Exports Pte",
+        amount: "22,000",
+        currency: "USD",
+        dueDate: "2026-05-30",
+        yield: "9.1%",
+        status: "Open",
+      },
+    ];
+
+    const loadInvoices = createDeferredLoader(invoices, 100);
+    const { rerender } = render(<InvestMarketplace loadInvoices={loadInvoices} />);
+
+    expect(screen.getByRole("list", { name: /loading investable invoices/i })).toHaveAttribute(
+      "aria-busy",
+      "true",
+    );
+
+    await flushTimers(100);
+
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "3 investable invoices loaded",
+    );
+    expect(screen.getAllByRole("listitem")).toHaveLength(3);
+    expect(screen.getByRole("status")).toHaveAttribute(
+      "aria-live",
+      "polite",
+    );
+    expect(loadInvoices).toHaveBeenCalledTimes(1);
+
+    rerender(<InvestMarketplace loadInvoices={loadInvoices} />);
+
+    expect(loadInvoices).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "3 investable invoices loaded",
+    );
+  });
+
+  it("announces the empty marketplace state when no invoices load", async () => {
+    const loadInvoices = createDeferredLoader([], 100);
+
+    render(<InvestMarketplace loadInvoices={loadInvoices} />);
+
+    await flushTimers(100);
+
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "No invoices available",
+    );
+    expect(
+      screen.getByText(/No investable invoices\. Connect wallet to see the marketplace\./i),
+    ).toBeInTheDocument();
+  });
+
+  it("announces load errors through an alert and live region", async () => {
+    const loadInvoices = jest.fn(
+      () =>
+        new Promise((_, reject) => {
+          setTimeout(() => reject(new Error("boom")), 50);
+        }),
+    );
+
+    render(<InvestMarketplace loadInvoices={loadInvoices} />);
+
+    await flushTimers(50);
+
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "Unable to load investable invoices.",
+    );
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "Unable to load investable invoices right now.",
+    );
+  });
+});
+
+describe("getInvoiceLoadAnnouncement", () => {
+  it("returns the expected announcement for loaded and empty states", () => {
+    expect(getInvoiceLoadAnnouncement([])).toBe("No invoices available");
+    expect(getInvoiceLoadAnnouncement([{ id: "1" }, { id: "2" }])).toBe(
+      "2 investable invoices loaded",
+    );
+  });
+});

--- a/components/InvoiceListSkeleton.jsx
+++ b/components/InvoiceListSkeleton.jsx
@@ -9,7 +9,11 @@
  */
 export default function InvoiceListSkeleton({ rows = 3 }) {
   return (
-    <ul aria-label="Loading invoices" aria-busy="true" className="space-y-4">
+    <ul
+      aria-label="Loading investable invoices"
+      aria-busy="true"
+      className="space-y-4"
+    >
       {Array.from({ length: rows }).map((_, i) => (
         <li
           key={i}

--- a/components/InvoiceListSkeleton.test.jsx
+++ b/components/InvoiceListSkeleton.test.jsx
@@ -26,7 +26,7 @@ describe("InvoiceListSkeleton", () => {
     const { container } = render(<InvoiceListSkeleton />);
     expect(
       container.querySelector("ul").getAttribute("aria-label")
-    ).toBe("Loading invoices");
+    ).toBe("Loading investable invoices");
   });
 
   it("each row has animate-pulse class", () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "react-dom": "19.2.3"
       },
       "devDependencies": {
-        "@playwright/test": "^1.60.0",
         "@tailwindcss/postcss": "^4",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",


### PR DESCRIPTION
## Linked issue

Closes #62

## What changed and why

This PR improves the screen-reader experience on the `/invest` marketplace by adding a polite live-region announcement when the mock invoice loading delay resolves. Previously, screen-reader users were informed that the application was busy loading (via the skeleton), but they were never notified when the loading actually finished. We have now introduced a visually hidden `aria-live="polite"` status message that explicitly announces "N investable invoices loaded" or "No invoices available" exactly once per transition. Additionally, this PR introduces a robust error fallback state using the `ErrorBanner` component and documents this new accessibility feature in the README.

## Test plan

- [x] Tested locally to ensure the announcement triggers correctly and without re-render spam.
- [x] Added automated tests via React Testing Library (`app/invest/page.test.jsx`) asserting the UI handles loading, loaded, empty, and error states properly.
- [x] Validated that the `aria-busy` skeleton state remains intact before resolution.
- [x] Run `npm run lint` and verify there are no warnings.
- [x] Run `npm run build` and confirm production build succeeds (Next.js static generation passes).

## Breaking changes

None

## Notes for reviewers

- **Effect Cleanup:** Refactored the `useEffect` inside `InvestMarketplace` to only commit state when the data actually resolves, preventing synchronous state-setting lint warnings.
- **Error Handling:** Added an `ErrorBanner` UI fallback. If the mock loader eventually gets replaced with a real API and throws, we now gracefully show an error banner and announce "Unable to load investable invoices right now."
- **Dependencies:** The `package-lock.json` might show some minor churn due to running `npm install` (e.g., stripping out an unused `@playwright/test` entry).
- **Build Note:** If you see any local build warnings regarding Google Fonts fetching, it is just a network timeout constraint and is unrelated to these changes.